### PR TITLE
Allow url option to be a function

### DIFF
--- a/backbone.service.js
+++ b/backbone.service.js
@@ -22,7 +22,7 @@
     var self = this;
     options || (options = {})
     return {
-      url: this.options.url + target.path,
+      url: _.result(this.options, 'url') + target.path,
       data: data,
       success: function (resp, status, xhr) {
         options.success && options.success.call(self, resp);

--- a/specs/backbone.service_spec.js
+++ b/specs/backbone.service_spec.js
@@ -46,6 +46,16 @@ describe('backbone.service', function () {
         expect(options.error).to.be.a('function');
         expect(options.data.param).to.equal(true);
       });
+
+      it("should accept url function", function() {
+        this.options.url = function() {
+          return 'http://localhost';
+        };
+        
+        var service = new Backbone.Service(this.options);
+        var options = service.createOptions(null, { path: '/ping' });
+        expect(options.url).to.equal('http://localhost/ping');
+      });
     });
 
     describe("new target methods", function () {


### PR DESCRIPTION
Uses `_.result` like Backbone core.
